### PR TITLE
Добавлены аргументы в Dockerfile для успешной сборки на hassio 2023.09

### DIFF
--- a/addons/mqtt-sber-gate/Dockerfile
+++ b/addons/mqtt-sber-gate/Dockerfile
@@ -1,4 +1,7 @@
 ARG BUILD_FROM
+ARG BUILD_DATE                             
+ARG BUILD_REF                              
+ARG BUILD_VERSION 
 FROM $BUILD_FROM
 
 # Install requirements for add-on


### PR DESCRIPTION
для успешной сборки аддона на свежей версии HASS требуется добавить аргументы в Dockerfile - что и было сделано